### PR TITLE
Fix variable typo which blocks execution

### DIFF
--- a/assets/php/WpPostsStaticTask.class.php
+++ b/assets/php/WpPostsStaticTask.class.php
@@ -72,7 +72,7 @@ RESULT;
 			$objWpPosts->PostMimeType = "";
 			$objWpPosts->CommentCount = 0;
 			$objWpPosts->Save();
-			$this->intPostCount++;
+			$this->intPostsCount++;
 		}
 		/**
 		 * @return int The number of object in the DLE database to process.

--- a/assets/php/WpPostsTask.class.php
+++ b/assets/php/WpPostsTask.class.php
@@ -66,7 +66,7 @@ RESULT;
 					$objWpPosts->PostMimeType = "";
 					$objWpPosts->CommentCount = 0;
 					$objWpPosts->Save();
-					$this->intPostCount++;
+					$this->intPostsCount++;
 				}
 			}
 		}


### PR DESCRIPTION
Из-за ошибки в названии переменной скрипт падает после первого обработанного поста/записи.